### PR TITLE
README.md: replace iosquak with golidlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All contributions are licensed to us under the
 License
 ----------------------------------------
 
-IOSqueak is licensed under the BSD-3 License. (See LICENSE.md)
+goldilocks is licensed under the BSD-3 License. (See LICENSE.md)
 
 The project is owned and maintained by [MousePaw Media](https://mousepawmedia.com/developers).
 


### PR DESCRIPTION
The current "License" section mentions "iosqueak". This looks like a copy/paste to me, it probably should say `goldilocks` here.